### PR TITLE
[NEW] Implement Rocket.Chat markdown

### DIFF
--- a/Pod/Classes/LTBaseParser.swift
+++ b/Pod/Classes/LTBaseParser.swift
@@ -31,8 +31,7 @@ open class TSBaseParser {
         return attributedStringFromAttributedMarkdownString(NSAttributedString(string: markdown, attributes: attributes))
     }
     
-    open func attributedStringFromAttributedMarkdownString(_ attributedString: NSAttributedString?) -> NSAttributedString? {
-        guard let attributedString = attributedString else { return nil }
+    open func attributedStringFromAttributedMarkdownString(_ attributedString: NSAttributedString) -> NSAttributedString {
         let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
         
         for expressionBlockPair in parsingPairs {

--- a/Pod/Classes/RCBaseParser.swift
+++ b/Pod/Classes/RCBaseParser.swift
@@ -1,27 +1,17 @@
-//
-//  TSBaseParser.swift
-//  LTMarkdownParser
-//
-//  Created by Rhett Rogers on 3/24/16.
-//  Copyright © 2016 CocoaPods. All rights reserved.
-//
-
 import Foundation
 
-open class TSBaseParser {
+open class RCBaseParser {
 
-    public typealias LTMarkdownParserMatchBlock = ((NSTextCheckingResult, NSMutableAttributedString) -> Void)
+    public typealias RCMarkdownParserMatchBlock = ((NSTextCheckingResult, NSMutableAttributedString) -> Void)
     
-    struct TSExpressionBlockPair {
-        
+    struct RCExpressionBlockPair {
         var regularExpression: NSRegularExpression
-        var block: LTMarkdownParserMatchBlock
-        
+        var block: RCMarkdownParserMatchBlock
     }
     
     open var defaultAttributes = [String: Any]()
     
-    fileprivate var parsingPairs = [TSExpressionBlockPair]()
+    fileprivate var parsingPairs = [RCExpressionBlockPair]()
     
     open func attributedStringFromMarkdown(_ markdown: String) -> NSAttributedString? {
         return attributedStringFromMarkdown(markdown, attributes: defaultAttributes)
@@ -41,11 +31,11 @@ open class TSBaseParser {
         return mutableAttributedString
     }
     
-    func parseExpressionBlockPairForMutableString(_ mutableAttributedString: NSMutableAttributedString, expressionBlockPair: TSExpressionBlockPair) {
+    func parseExpressionBlockPairForMutableString(_ mutableAttributedString: NSMutableAttributedString, expressionBlockPair: RCExpressionBlockPair) {
         parseExpressionForMutableString(mutableAttributedString, expression: expressionBlockPair.regularExpression, block: expressionBlockPair.block)
     }
     
-    func parseExpressionForMutableString(_ mutableAttributedString: NSMutableAttributedString, expression: NSRegularExpression, block: LTMarkdownParserMatchBlock) {
+    func parseExpressionForMutableString(_ mutableAttributedString: NSMutableAttributedString, expression: NSRegularExpression, block: RCMarkdownParserMatchBlock) {
         var location = 0
         
         while let match = expression.firstMatch(in: mutableAttributedString.string, options: .withoutAnchoringBounds, range: NSRange(location: location, length: mutableAttributedString.length - location)) {
@@ -56,8 +46,8 @@ open class TSBaseParser {
         }
     }
     
-    open func addParsingRuleWithRegularExpression(_ regularExpression: NSRegularExpression, block: @escaping LTMarkdownParserMatchBlock) {
-        parsingPairs.append(TSExpressionBlockPair(regularExpression: regularExpression, block: block))
+    open func addParsingRuleWithRegularExpression(_ regularExpression: NSRegularExpression, block: @escaping RCMarkdownParserMatchBlock) {
+        parsingPairs.append(RCExpressionBlockPair(regularExpression: regularExpression, block: block))
     }
     
 }

--- a/Pod/Classes/RCMarkdownParser.swift
+++ b/Pod/Classes/RCMarkdownParser.swift
@@ -23,7 +23,9 @@ public struct RCMarkdownRegex {
     public static let AlternateLink = "(?:<|&lt;)((?:\(_allowedSchemes)):\\/\\/[^\\|]+)\\|(.+?)(?=>|&gt;)(?:>|&gt;)"
     public static let AlternateLinkOptions: NSRegularExpression.Options = [.anchorsMatchLines]
     
-    public static let Monospace = "(`+)(\\s*.*?[^`]\\s*)(\\1)(?!`)"
+    public static let InlineCode = "(?:^|&gt;|[ >_*~])(\\`)([^`\r\n]+)(\\`)(?:[<_*~]|\\B|\\b|$)"
+    public static let InlineCodeOptions: NSRegularExpression.Options = [.anchorsMatchLines]
+
     public static let Strong = "(?:^|&gt;|[ >_~`])(\\*{1,2})([^\\*\r\n]+)(\\*{1,2})(?:[<_~`]|\\B|\\b|$)"
     public static let StrongOptions: NSRegularExpression.Options = [.anchorsMatchLines]
     public static let Italic = "(?:^|&gt;|[ >*~`])(\\_{1,2})([^\\_\r\n]+)(\\_{1,2})(?:[<*~`]|\\B|\\b|$)"
@@ -52,7 +54,7 @@ open class RCMarkdownParser: RCBaseParser {
     
     open var imageAttributes = [String: Any]()
     open var linkAttributes = [String: Any]()
-    open var monospaceAttributes = [String: Any]()
+    open var inlineCodeAttributes = [String: Any]()
     open var strongAttributes = [String: Any]()
     open var italicAttributes = [String: Any]()
     open var strongAndItalicAttributes = [String: Any]()
@@ -85,6 +87,11 @@ open class RCMarkdownParser: RCBaseParser {
         strongAndItalicAttributes = [NSFontAttributeName: strongAndItalicFont]
         
         if withDefaultParsing {
+
+            addInlineCodeParsingWithFormattingBlock { attributedString, range in
+                attributedString.addAttributes(self.inlineCodeAttributes, range: range)
+            }
+
             addStrongParsingWithFormattingBlock { attributedString, range in
                 attributedString.enumerateAttributes(in: range, options: []) { attributes, range, _ in
                     if let font = attributes[NSFontAttributeName] as? UIFont, let italicFont = self.italicAttributes[NSFontAttributeName] as? UIFont, font == italicFont {
@@ -261,8 +268,8 @@ open class RCMarkdownParser: RCBaseParser {
         }
     }
     
-    open func addMonospacedParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
-        addEnclosedParsingWithPattern(RCMarkdownRegex.Monospace, formattingBlock: formattingBlock)
+    open func addInlineCodeParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
+        addEnclosedParsingWithPattern(RCMarkdownRegex.InlineCode, options: RCMarkdownRegex.InlineCodeOptions, formattingBlock: formattingBlock)
     }
     
     open func addStrongParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {

--- a/Pod/Classes/RCMarkdownParser.swift
+++ b/Pod/Classes/RCMarkdownParser.swift
@@ -32,6 +32,8 @@ public struct RCMarkdownRegex {
     public static let StrongOptions: NSRegularExpression.Options = [.anchorsMatchLines]
     public static let Italic = "(?:^|&gt;|[ >*~`])(\\_{1,2})([^\\_\r\n]+)(\\_{1,2})(?:[<*~`]|\\B|\\b|$)"
     public static let ItalicOptions: NSRegularExpression.Options = [.anchorsMatchLines]
+    public static let Strike = "(?:^|&gt;|[ >_*`])(\\~{1,2})([^~\r\n]+)(\\~{1,2})(?:[<_*`]|\\B|\\b|$)"
+    public static let StrikeOptions: NSRegularExpression.Options = [.anchorsMatchLines]
     
     public static func regexForString(_ regexString: String, options: NSRegularExpression.Options = []) -> NSRegularExpression? {
         do {
@@ -58,6 +60,7 @@ open class RCMarkdownParser: TSBaseParser {
     open var strongAttributes = [String: Any]()
     open var italicAttributes = [String: Any]()
     open var strongAndItalicAttributes = [String: Any]()
+    open var strikeAttributes = [String: Any]()
     
     open static var standardParser = RCMarkdownParser()
     
@@ -98,6 +101,10 @@ open class RCMarkdownParser: TSBaseParser {
                         attributedString.addAttributes(self.italicAttributes, range: range)
                     }
                 }
+            }
+
+            addStrikeParsingWithFormattingBlock { attributedString, range in
+                attributedString.addAttributes(self.strikeAttributes, range: range)
             }
         }
     }
@@ -238,7 +245,11 @@ open class RCMarkdownParser: TSBaseParser {
     open func addItalicParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
         addEnclosedParsingWithPattern(RCMarkdownRegex.Italic, options: RCMarkdownRegex.ItalicOptions, formattingBlock: formattingBlock)
     }
-    
+
+    open func addStrikeParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
+        addEnclosedParsingWithPattern(RCMarkdownRegex.Strike, options: RCMarkdownRegex.StrikeOptions, formattingBlock: formattingBlock)
+    }
+
     open func addLinkDetectionWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
         do {
             let linkDataDetector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)

--- a/Pod/Classes/RCMarkdownParser.swift
+++ b/Pod/Classes/RCMarkdownParser.swift
@@ -25,6 +25,8 @@ public struct RCMarkdownRegex {
     
     public static let InlineCode = "(?:^|&gt;|[ >_*~])(\\`)([^`\r\n]+)(\\`)(?:[<_*~]|\\B|\\b|$)"
     public static let InlineCodeOptions: NSRegularExpression.Options = [.anchorsMatchLines]
+    public static let Code = "(```)(?:[a-zA-Z]+)?((?:.|\r|\n)*?)(```)"
+    public static let CodeOptions: NSRegularExpression.Options = [.anchorsMatchLines]
 
     public static let Strong = "(?:^|&gt;|[ >_~`])(\\*{1,2})([^\\*\r\n]+)(\\*{1,2})(?:[<_~`]|\\B|\\b|$)"
     public static let StrongOptions: NSRegularExpression.Options = [.anchorsMatchLines]
@@ -55,6 +57,7 @@ open class RCMarkdownParser: RCBaseParser {
     open var imageAttributes = [String: Any]()
     open var linkAttributes = [String: Any]()
     open var inlineCodeAttributes = [String: Any]()
+    open var codeAttributes = [String: Any]()
     open var strongAttributes = [String: Any]()
     open var italicAttributes = [String: Any]()
     open var strongAndItalicAttributes = [String: Any]()
@@ -90,6 +93,10 @@ open class RCMarkdownParser: RCBaseParser {
 
             addInlineCodeParsingWithFormattingBlock { attributedString, range in
                 attributedString.addAttributes(self.inlineCodeAttributes, range: range)
+            }
+
+            addCodeParsingWithFormattingBlock { attributedString, range in
+                attributedString.addAttributes(self.codeAttributes, range: range)
             }
 
             addStrongParsingWithFormattingBlock { attributedString, range in
@@ -270,6 +277,10 @@ open class RCMarkdownParser: RCBaseParser {
     
     open func addInlineCodeParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
         addEnclosedParsingWithPattern(RCMarkdownRegex.InlineCode, options: RCMarkdownRegex.InlineCodeOptions, formattingBlock: formattingBlock)
+    }
+
+    open func addCodeParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {
+        addEnclosedParsingWithPattern(RCMarkdownRegex.Code, formattingBlock: formattingBlock)
     }
     
     open func addStrongParsingWithFormattingBlock(_ formattingBlock: @escaping RCMarkdownParserFormattingBlock) {

--- a/RCMarkdownParser.podspec
+++ b/RCMarkdownParser.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "RCMarkdownParser"
-  s.version          = "2.0.2"
+  s.version          = “1.0.0”
   s.summary          = "A markdown parser written in swift"
 
 # This description is used to generate tags and improve search results.
@@ -20,11 +20,11 @@ Pod::Spec.new do |s|
     A parser written to convert a string containing markdown to an NSAttributedString for Rocket.Chat. It was based off of LTMarkdownParser.
                        DESC
 
-  s.homepage         = "https://github.com/cardoso/RCMarkdownParser"
+  s.homepage         = "https://github.com/RocketChat/RCMarkdownParser"
   # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license          = 'MIT'
   s.author           = { "Matheus Cardoso" => "matheus@cardo.so" }
-  s.source           = { :git => "https://github.com/cardoso/RCMarkdownParser.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/RocketChat/RCMarkdownParser.git", :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.platform     = :ios, '8.0'


### PR DESCRIPTION
Closes: #1 

# TODO:
- [x] Support \*text\* to make *bold*
- [x] Support \_text\_ to make _italics_
- [x] Support \~text\~ to strike through ~text~
- [x] Support ![alt text](http://image url)
- [x] Support \[Text](http://link)
- [x] Support <http://link|Text>
- [x] Support # for headers (h1, h2 , h3, h4)
- [x] Support for block quote
> This is how a block quote
should look like
- [x] Support >Text for quote
>Text
- [x] Support inline code
```printf("Hello %s!", "World!");```
- [x] Support block code
```
void main() {
    printf("Hello %s!", "World!");
}
```